### PR TITLE
Add Test for LetterQueue to verify visibilityTimeStamp

### DIFF
--- a/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
+++ b/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import getRestApiGatewayBaseUrl from "tests/helpers/aws-gateway-helper";
 import { pollForLetterStatus } from "tests/helpers/poll-for-letters-helper";
 import { getLettersFromQueueViaIndex } from "tests/helpers/generate-fetch-test-data";
@@ -9,6 +9,12 @@ import {
   verifyAllocationLogsContainPriority,
   verifyIndexPositionOfLetterVariants,
 } from "tests/helpers/urgent-letter-priority-helper";
+import { createValidRequestHeaders } from "tests/constants/request-headers";
+import { SUPPLIER_LETTERS } from "tests/constants/api-constants";
+import {
+  GetLettersResponse,
+  GetLettersResponseSchema,
+} from "../../../lambdas/api-handler/src/contracts/letters";
 
 let baseUrl: string;
 
@@ -40,6 +46,21 @@ test.describe("Urgent Letter Priority Tests", () => {
     const letterIdsFromQueue = lettersFromQueue.map(
       (letter) => letter.letterId,
     );
+
+    const header = createValidRequestHeaders(supplier);
+    const response = await request.get(`${baseUrl}/${SUPPLIER_LETTERS}`, {
+      headers: header,
+    });
+
+    expect(response.status()).toBe(200);
+    const responseBody = await response.json();
+    expect(responseBody.data.length).toBeGreaterThanOrEqual(1);
+
+    const getLettersResponse: GetLettersResponse =
+      GetLettersResponseSchema.parse(responseBody);
+
+    const letterIds = getLettersResponse.data.map((letter) => letter.id);
+    expect(letterIds).toEqual(letterIdsFromQueue);
 
     verifyIndexPositionOfLetterVariants(
       letterIdsFromQueue,

--- a/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
+++ b/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
@@ -7,7 +7,7 @@ import {
 import { logger } from "tests/helpers/pino-logger";
 import { sendSnsBatchEvent, sendSnsEvent } from "tests/helpers/send-sns-event";
 import {
-  pollUpsertLetterLogForError,
+  pollUpsertLetterLogForWarning,
   supplierIdFromSupplierAllocatorLog,
 } from "tests/helpers/aws-cloudwatch-helper";
 import getRestApiGatewayBaseUrl from "tests/helpers/aws-gateway-helper";
@@ -106,10 +106,7 @@ test.describe("Letter Queue Tests", () => {
     expect(letterExists).toBe(true);
     expect(itemCount).toBe(1);
 
-    await pollUpsertLetterLogForError(
-      `Letter with id ${letterId} already exists for supplier ${supplierId}"`,
-      letterId,
-    );
+    await pollUpsertLetterLogForWarning("Letter already exists", letterId);
   });
 
   test("Verify if VisibilityTimeStamp is updated when Get /letters endpoint is called and subsequent calls returns no data until VisibilityTimeStamp is reached", async ({

--- a/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
+++ b/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
@@ -7,13 +7,17 @@ import {
 import { logger } from "tests/helpers/pino-logger";
 import { sendSnsBatchEvent, sendSnsEvent } from "tests/helpers/send-sns-event";
 import {
-  pollUpsertLetterLogForWarning,
+  pollUpsertLetterLogForError,
   supplierIdFromSupplierAllocatorLog,
 } from "tests/helpers/aws-cloudwatch-helper";
 import getRestApiGatewayBaseUrl from "tests/helpers/aws-gateway-helper";
 import { SUPPLIER_LETTERS } from "tests/constants/api-constants";
 import { supplierDataSetup } from "tests/helpers/suppliers-setup-helper";
-import { checkLetterQueueTable } from "tests/helpers/generate-fetch-test-data";
+import {
+  checkLetterQueueTable,
+  getLetterFromQueueById,
+} from "tests/helpers/generate-fetch-test-data";
+import { createValidRequestHeaders } from "../../constants/request-headers";
 import {
   patchRequestHeaders,
   patchValidRequestBody,
@@ -102,6 +106,70 @@ test.describe("Letter Queue Tests", () => {
     expect(letterExists).toBe(true);
     expect(itemCount).toBe(1);
 
-    await pollUpsertLetterLogForWarning("Letter already exists", letterId);
+    await pollUpsertLetterLogForError(
+      `Letter with id ${letterId} already exists for supplier ${supplierId}"`,
+      letterId,
+    );
+  });
+
+  test("Verify if VisibilityTimeStamp is updated when Get /letters endpoint is called and subsequent calls returns no data until VisibilityTimeStamp is reached", async ({
+    request,
+  }) => {
+    const letterId = randomUUID();
+    logger.info(`Sending event with domainId: ${letterId}`);
+    const preparedEvent = createPreparedV1Event({ domainId: letterId });
+    const response = await sendSnsEvent(preparedEvent);
+
+    expect(response.MessageId).toBeTruthy();
+
+    const supplierId = await supplierIdFromSupplierAllocatorLog(letterId);
+
+    await supplierDataSetup(supplierId);
+
+    const letters = await getLetterFromQueueById(supplierId, letterId);
+    expect(letters).toHaveLength(1);
+    const letter = letters[0];
+    expect(letter.visibilityTimestamp).toBe(letter.queueTimestamp);
+    logger.info(
+      "Visibility timestamp is same as queue timestamp before calling Get /letters endpoint",
+    );
+
+    // call get letters endpoint which should update the visibility timestamp
+    const header = createValidRequestHeaders(supplierId);
+    const getLettersResponse = await request.get(
+      `${baseUrl}/${SUPPLIER_LETTERS}`,
+      {
+        headers: header,
+      },
+    );
+
+    expect(getLettersResponse.status()).toBe(200);
+    const currentTimeWithTimeOut = Math.floor(
+      (Date.now() + 5 * 60 * 1000) / 1000,
+    );
+
+    logger.info(
+      "Called Get /letters endpoint verify visibility timestamp is updated and subsequent calls returns no data until visibility timestamp is reached",
+    );
+    const lettersAfterGet = await getLetterFromQueueById(supplierId, letterId);
+    const visibilityTimestampAfterGet = Math.floor(
+      new Date(lettersAfterGet[0].visibilityTimestamp).getTime() / 1000,
+    );
+
+    // allow a 1 second tolerance
+    expect(
+      Math.abs(visibilityTimestampAfterGet - currentTimeWithTimeOut),
+    ).toBeLessThanOrEqual(1);
+
+    const getLettersWithInVisibility = await request.get(
+      `${baseUrl}/${SUPPLIER_LETTERS}`,
+      {
+        headers: header,
+      },
+    );
+
+    expect(getLettersWithInVisibility.status()).toBe(200);
+    const responseBody = await getLettersWithInVisibility.json();
+    expect(responseBody.data).toHaveLength(0);
   });
 });

--- a/tests/helpers/generate-fetch-test-data.ts
+++ b/tests/helpers/generate-fetch-test-data.ts
@@ -263,3 +263,46 @@ export async function getLettersFromQueueViaIndex(
     return [];
   }
 }
+
+export async function getLetterFromQueueById(
+  supplierId: string,
+  letterId: string,
+): Promise<PendingLetter[]> {
+  const MAX_ATTEMPTS = 5;
+  const RETRY_DELAY_MS = 10_000;
+
+  try {
+    const params = {
+      TableName: LETTERQUEUE_TABLENAME,
+      KeyConditionExpression:
+        "supplierId = :supplierId AND letterId = :letterId",
+      ExpressionAttributeValues: {
+        ":supplierId": supplierId,
+        ":letterId": letterId,
+      },
+    };
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      const { Items } = await docClient.send(new QueryCommand(params));
+
+      if (Items !== undefined && Items.length > 0) {
+        logger.info(
+          `Queried letter queue table to verify existence for supplier ${supplierId} and found items.`,
+        );
+
+        // assumes no pagination needed as we expect a small number of letters in the queue for the test supplier
+        return z.array(PendingLetterSchema).parse(Items);
+      }
+      if (attempt < MAX_ATTEMPTS) {
+        logger.info(
+          `Retrying get letters from queue for supplierId ${supplierId} in ${RETRY_DELAY_MS}ms`,
+        );
+        await delay(RETRY_DELAY_MS);
+      }
+    }
+    return [];
+  } catch (error) {
+    logger.error({ supplierId, error }, "Letter queue query failed");
+    return [];
+  }
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
