### PR TITLE
CCM-15589: Fix Tests

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -25,3 +25,9 @@ debc75a97cfe551a69fd1e8694be483213322a9d:pact-contracts/pacts/letter-rendering/s
 4fa1923947bbff2387218d698d766cbb7c121a0f:pact-contracts/pacts/letter-rendering/supplier-api-letter-request-prepared.json:generic-api-key:10
 d005112adcfd286c3bef076214836dbb2fe8d0b5:.npmrc:npm-access-token:9
 d005112adcfd286c3bef076214836dbb2fe8d0b5:.npmrc:github-pat:7
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js.map:ipv4:4
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js:ipv4:63
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js:ipv4:62
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js:ipv4:60
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js:ipv4:59
+ff889d4c3f29da4468ecf1f05f467fe84d35b2a1:lambdas/supplier-mock/.aws-sam/build/SupplierMockFunction/index.js:ipv4:24

--- a/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
+++ b/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 import getRestApiGatewayBaseUrl from "tests/helpers/aws-gateway-helper";
 import { pollForLetterStatus } from "tests/helpers/poll-for-letters-helper";
 import { getLettersFromQueueViaIndex } from "tests/helpers/generate-fetch-test-data";
@@ -9,12 +9,6 @@ import {
   verifyAllocationLogsContainPriority,
   verifyIndexPositionOfLetterVariants,
 } from "tests/helpers/urgent-letter-priority-helper";
-import { createValidRequestHeaders } from "tests/constants/request-headers";
-import { SUPPLIER_LETTERS } from "tests/constants/api-constants";
-import {
-  GetLettersResponse,
-  GetLettersResponseSchema,
-} from "../../../lambdas/api-handler/src/contracts/letters";
 
 let baseUrl: string;
 
@@ -43,24 +37,10 @@ test.describe("Urgent Letter Priority Tests", () => {
     await verifyAllocationLogsContainPriority(urgencyTenLetterIds, 10);
 
     const lettersFromQueue = await getLettersFromQueueViaIndex(supplier);
+
     const letterIdsFromQueue = lettersFromQueue.map(
       (letter) => letter.letterId,
     );
-
-    const header = createValidRequestHeaders(supplier);
-    const response = await request.get(`${baseUrl}/${SUPPLIER_LETTERS}`, {
-      headers: header,
-    });
-
-    expect(response.status()).toBe(200);
-    const responseBody = await response.json();
-    expect(responseBody.data.length).toBeGreaterThanOrEqual(1);
-
-    const getLettersResponse: GetLettersResponse =
-      GetLettersResponseSchema.parse(responseBody);
-
-    const letterIds = getLettersResponse.data.map((letter) => letter.id);
-    expect(letterIds).toEqual(letterIdsFromQueue);
 
     verifyIndexPositionOfLetterVariants(
       letterIdsFromQueue,

--- a/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
+++ b/tests/component-tests/integration-tests/urgent-letter-priority.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import getRestApiGatewayBaseUrl from "tests/helpers/aws-gateway-helper";
 import { pollForLetterStatus } from "tests/helpers/poll-for-letters-helper";
 import { getLettersFromQueueViaIndex } from "tests/helpers/generate-fetch-test-data";
@@ -9,6 +9,12 @@ import {
   verifyAllocationLogsContainPriority,
   verifyIndexPositionOfLetterVariants,
 } from "tests/helpers/urgent-letter-priority-helper";
+import { createValidRequestHeaders } from "tests/constants/request-headers";
+import { SUPPLIER_LETTERS } from "tests/constants/api-constants";
+import {
+  GetLettersResponse,
+  GetLettersResponseSchema,
+} from "../../../lambdas/api-handler/src/contracts/letters";
 
 let baseUrl: string;
 
@@ -41,6 +47,21 @@ test.describe("Urgent Letter Priority Tests", () => {
     const letterIdsFromQueue = lettersFromQueue.map(
       (letter) => letter.letterId,
     );
+
+    const header = createValidRequestHeaders(supplier);
+    const response = await request.get(`${baseUrl}/${SUPPLIER_LETTERS}`, {
+      headers: header,
+    });
+
+    expect(response.status()).toBe(200);
+    const responseBody = await response.json();
+    expect(responseBody.data.length).toBeGreaterThanOrEqual(1);
+
+    const getLettersResponse: GetLettersResponse =
+      GetLettersResponseSchema.parse(responseBody);
+
+    const letterIds = getLettersResponse.data.map((letter) => letter.id);
+    expect(letterIds).toEqual(letterIdsFromQueue);
 
     verifyIndexPositionOfLetterVariants(
       letterIdsFromQueue,

--- a/tests/config/main.config.ts
+++ b/tests/config/main.config.ts
@@ -13,6 +13,7 @@ const localConfig: PlaywrightTestConfig = {
       name: "apiGateway-tests",
       testDir: path.resolve(__dirname, "../component-tests/apiGateway-tests"),
       testMatch: "**/*.spec.ts",
+      dependencies: ["integration-tests"],
     },
     {
       name: "events-tests",
@@ -24,6 +25,7 @@ const localConfig: PlaywrightTestConfig = {
       name: "letterQueue-tests",
       testDir: path.resolve(__dirname, "../component-tests/letterQueue-tests"),
       testMatch: "**/*.spec.ts",
+      dependencies: ["apiGateway-tests"],
     },
     {
       name: "integration-tests",

--- a/tests/helpers/urgent-letter-priority-helper.ts
+++ b/tests/helpers/urgent-letter-priority-helper.ts
@@ -95,6 +95,9 @@ export function verifyIndexPositionOfLetterVariants(
 
   // All higher-urgency letters must appear before any lower-urgency letter
   expect(highestUrgencyMaxIndex).toBeLessThan(lowerUrgencyMinIndex);
+  logger.info(
+    `Verified all higher urgency letters appear before lower urgency letters in index. Highest index for urgency ${variantUrgencyMap[letterIdsHigherUrgency[0]]} was ${highestUrgencyMaxIndex}, lowest index for urgency ${variantUrgencyMap[letterIdsLowerUrgency[0]]} was ${lowerUrgencyMinIndex}`,
+  );
 }
 
 export async function verifyAllocationLogsContainPriority(
@@ -111,5 +114,8 @@ export async function verifyAllocationLogsContainPriority(
     expect(supplierSpec).toBeDefined();
     expect(supplierSpec.priority).toBeDefined();
     expect(supplierSpec.priority).toBe(priority);
+    logger.info(
+      `Verified log for domainId ${domainId} contains priority ${priority}`,
+    );
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
