### PR TITLE
CCM-18631: stabilise component tests

### DIFF
--- a/specification/api/components/environments/internal-dev/target.yml
+++ b/specification/api/components/environments/internal-dev/target.yml
@@ -3,4 +3,4 @@ healthcheck: /_status
 url: https://suppliers.dev.nhsnotify.national.nhs.uk
 security:
   type: mtls
-  secret: nhs-notify-supplier-mtls-internal-dev
+  secret: nhs-notify-supplier-mtls-internal-dev-main

--- a/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
+++ b/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
@@ -73,8 +73,7 @@ test.describe("API Gateway Tests to Verify Get Letter PDF Endpoint", () => {
     const id = "non-existing-id-12345";
     const headers = createValidRequestHeaders();
     const response = await request.get(
-      `
-      ${baseUrl}/${SUPPLIER_LETTERS}/${id}/${DATA}`,
+      `${baseUrl}/${SUPPLIER_LETTERS}/${id}/${DATA}`,
       {
         headers,
       },

--- a/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
+++ b/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 import getRestApiGatewayBaseUrl from "../../helpers/aws-gateway-helper";
-import { getLettersBySupplier } from "../../helpers/generate-fetch-test-data";
+import {
+  createTestData,
+  waitForLetterStatus,
+} from "../../helpers/generate-fetch-test-data";
 import {
   DATA,
   SUPPLIERID,
@@ -19,16 +22,17 @@ test.describe("API Gateway Tests to Verify Get Letter PDF Endpoint", () => {
   test(`Get /letters/{id}/data returns 200 and valid response for a given id`, async ({
     request,
   }) => {
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 1);
+    const letterIds: string[] = await createTestData(SUPPLIERID);
+    const createdLetter = await waitForLetterStatus(
+      SUPPLIERID,
+      letterIds[0],
+      "PENDING",
+    );
 
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
-    const letter = letters[0];
     const headers = createValidRequestHeaders();
+
     const response = await request.get(
-      `${baseUrl}/${SUPPLIER_LETTERS}/${letter.id}/${DATA}`,
+      `${baseUrl}/${SUPPLIER_LETTERS}/${createdLetter.id}/${DATA}`,
       {
         headers,
       },
@@ -63,24 +67,6 @@ test.describe("API Gateway Tests to Verify Get Letter PDF Endpoint", () => {
     expect(after.status).toBe(403);
   });
 
-  test(`Get /letters/{id}/data returns 404 if no resource is found for id`, async ({
-    request,
-  }) => {
-    const id = "11";
-    const headers = createValidRequestHeaders();
-    const response = await request.get(
-      `${baseUrl}/${SUPPLIER_LETTERS}/${id}/${DATA}`,
-      {
-        headers,
-      },
-    );
-
-    const responseBody = await response.json();
-    expect(response.status()).toBe(404);
-    expect(responseBody).toMatchObject(error404ResponseBody());
-  });
-
-  // CCM-14318: Remove this test
   test(`Get /letters/{id}/data returns 404 if letter is not found for supplierId ${SUPPLIERID}`, async ({
     request,
   }) => {

--- a/tests/component-tests/apiGateway-tests/get-letter-status.spec.ts
+++ b/tests/component-tests/apiGateway-tests/get-letter-status.spec.ts
@@ -1,6 +1,9 @@
 import { expect, test } from "@playwright/test";
 import getRestApiGatewayBaseUrl from "../../helpers/aws-gateway-helper";
-import { getLettersBySupplier } from "../../helpers/generate-fetch-test-data";
+import {
+  createTestData,
+  waitForLetterStatus,
+} from "../../helpers/generate-fetch-test-data";
 import { SUPPLIERID, SUPPLIER_LETTERS } from "../../constants/api-constants";
 import { createValidRequestHeaders } from "../../constants/request-headers";
 import { error404ResponseBody } from "../../helpers/common-types";
@@ -15,16 +18,16 @@ test.describe("API Gateway Tests to Verify Get Letter Status Endpoint", () => {
   test(`Get /letters/{id} returns 200 and valid response for a given id`, async ({
     request,
   }) => {
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 1);
+    const letterIds: string[] = await createTestData(SUPPLIERID);
+    const createdLetter = await waitForLetterStatus(
+      SUPPLIERID,
+      letterIds[0],
+      "PENDING",
+    );
 
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
-    const letter = letters[0];
     const headers = createValidRequestHeaders();
     const response = await request.get(
-      `${baseUrl}/${SUPPLIER_LETTERS}/${letter.id}`,
+      `${baseUrl}/${SUPPLIER_LETTERS}/${createdLetter.id}`,
       {
         headers,
       },
@@ -37,10 +40,10 @@ test.describe("API Gateway Tests to Verify Get Letter Status Endpoint", () => {
       data: {
         attributes: {
           status: "PENDING",
-          specificationId: letter.specificationId,
-          groupId: letter.groupId,
+          specificationId: createdLetter.specificationId,
+          groupId: createdLetter.groupId,
         },
-        id: letter.id,
+        id: createdLetter.id,
         type: "Letter",
       },
     });

--- a/tests/component-tests/apiGateway-tests/testCases/update-multiple-letter-status.ts
+++ b/tests/component-tests/apiGateway-tests/testCases/update-multiple-letter-status.ts
@@ -1,10 +1,10 @@
+import { Letter } from "@internal/datastore";
 import { RequestHeaders } from "../../../constants/request-headers";
 import { SUPPLIERID } from "../../../constants/api-constants";
 import {
   ErrorMessageBody,
   PostMessageRequestBody,
 } from "../../../helpers/common-types";
-import { SupplierApiLetters } from "../../../helpers/generate-fetch-test-data";
 
 export interface LetterUpdateAttributes {
   status: string;
@@ -43,7 +43,7 @@ export function postValidRequestBody(
 }
 
 export function postInvalidStatusRequestBody(
-  letters: SupplierApiLetters[],
+  letters: Letter[],
 ): PostMessageRequestBody {
   return {
     data: [
@@ -66,7 +66,7 @@ export function postInvalidStatusRequestBody(
 }
 
 export function postDuplicateIDRequestBody(
-  letters: SupplierApiLetters[],
+  letters: Letter[],
 ): PostMessageRequestBody {
   return {
     data: [

--- a/tests/component-tests/apiGateway-tests/update-letter-status.spec.ts
+++ b/tests/component-tests/apiGateway-tests/update-letter-status.spec.ts
@@ -10,7 +10,6 @@ import {
 } from "./testCases/update-letter-status";
 import {
   createTestData,
-  getLettersBySupplier,
   waitForLetterStatus,
 } from "../../helpers/generate-fetch-test-data";
 import { createInvalidRequestHeaders } from "../../constants/request-headers";
@@ -20,33 +19,26 @@ import {
 } from "../../helpers/common-types";
 
 let baseUrl: string;
-let letters: Awaited<ReturnType<typeof getLettersBySupplier>>;
 
 test.beforeAll(async () => {
   baseUrl = await getRestApiGatewayBaseUrl();
 });
 
 test.describe("API Gateway Tests to Verify Patch Status Endpoint", () => {
-  test.beforeAll(async () => {
-    await createTestData(SUPPLIERID, 2);
-    letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 2);
-
-    if (letters.length < 2) {
-      throw new Error(
-        `Expected 2 PENDING letters for supplier ${SUPPLIERID}, got ${letters.length}.`,
-      );
-    }
-  });
-
   test(`Patch /letters returns 202 and status is updated to ACCEPTED`, async ({
     request,
   }) => {
-    const letter = letters[0];
+    const letterIds: string[] = await createTestData(SUPPLIERID);
+    const createdLetter = await waitForLetterStatus(
+      SUPPLIERID,
+      letterIds[0],
+      "PENDING",
+    );
     const headers = patchRequestHeaders();
-    const body = patchValidRequestBody(letter.id, "ACCEPTED");
+    const body = patchValidRequestBody(createdLetter.id, "ACCEPTED");
 
     const response = await request.patch(
-      `${baseUrl}/${SUPPLIER_LETTERS}/${letter.id}`,
+      `${baseUrl}/${SUPPLIER_LETTERS}/${createdLetter.id}`,
       {
         headers,
         data: body,
@@ -57,7 +49,7 @@ test.describe("API Gateway Tests to Verify Patch Status Endpoint", () => {
 
     const updated = await waitForLetterStatus(
       SUPPLIERID,
-      letter.id,
+      createdLetter.id,
       "ACCEPTED",
     );
     expect(updated.status).toBe("ACCEPTED");
@@ -66,12 +58,17 @@ test.describe("API Gateway Tests to Verify Patch Status Endpoint", () => {
   test(`Patch /letters returns 202 and status is updated to REJECTED`, async ({
     request,
   }) => {
-    const letter = letters[1];
+    const letterIds: string[] = await createTestData(SUPPLIERID);
+    const createdLetter = await waitForLetterStatus(
+      SUPPLIERID,
+      letterIds[0],
+      "PENDING",
+    );
     const headers = patchRequestHeaders();
-    const body = patchFailureRequestBody(letter.id, "REJECTED");
+    const body = patchFailureRequestBody(createdLetter.id, "REJECTED");
 
     const response = await request.patch(
-      `${baseUrl}/${SUPPLIER_LETTERS}/${letter.id}`,
+      `${baseUrl}/${SUPPLIER_LETTERS}/${createdLetter.id}`,
       {
         headers,
         data: body,
@@ -82,7 +79,7 @@ test.describe("API Gateway Tests to Verify Patch Status Endpoint", () => {
 
     const updated = await waitForLetterStatus(
       SUPPLIERID,
-      letter.id,
+      createdLetter.id,
       "REJECTED",
     );
     expect(updated.status).toBe("REJECTED");

--- a/tests/component-tests/apiGateway-tests/update-multiple-letter-status.spec.ts
+++ b/tests/component-tests/apiGateway-tests/update-multiple-letter-status.spec.ts
@@ -13,7 +13,6 @@ import {
 } from "./testCases/update-multiple-letter-status";
 import {
   createTestData,
-  getLettersBySupplier,
   waitForLetterStatus,
 } from "../../helpers/generate-fetch-test-data";
 
@@ -27,24 +26,21 @@ test.describe("API Gateway Tests to Verify post Status Endpoint", () => {
   test(`post /letters returns 202 and status is updated for multiple letters`, async ({
     request,
   }) => {
-    await createTestData(SUPPLIERID, 4);
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 4);
-
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
+    const letterIds: string[] = await createTestData(SUPPLIERID, 4);
+    const createdLetters = await Promise.all(
+      letterIds.map((id) => waitForLetterStatus(SUPPLIERID, id, "PENDING")),
+    );
 
     const headers = postLettersRequestHeaders();
     const updatesById = {
-      [letters[0].id]: { status: "ACCEPTED" },
-      [letters[1].id]: {
+      [createdLetters[0].id]: { status: "ACCEPTED" },
+      [createdLetters[1].id]: {
         status: "REJECTED",
         reasonCode: "R01",
         reasonText: "Test Reason",
       },
-      [letters[2].id]: { status: "PRINTED" },
-      [letters[3].id]: { status: "CANCELLED" },
+      [createdLetters[2].id]: { status: "PRINTED" },
+      [createdLetters[3].id]: { status: "CANCELLED" },
     };
 
     const body = postValidRequestBody(updatesById);
@@ -71,16 +67,13 @@ test.describe("API Gateway Tests to Verify post Status Endpoint", () => {
   test(`Post /letters returns 400 if request has invalid status`, async ({
     request,
   }) => {
-    await createTestData(SUPPLIERID, 2);
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 2);
-
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
+    const letterIds: string[] = await createTestData(SUPPLIERID, 2);
+    const createdLetters = await Promise.all(
+      letterIds.map((id) => waitForLetterStatus(SUPPLIERID, id, "PENDING")),
+    );
 
     const headers = postLettersRequestHeaders();
-    const body = postInvalidStatusRequestBody(letters);
+    const body = postInvalidStatusRequestBody(createdLetters);
 
     const response = await request.post(`${baseUrl}/${SUPPLIER_LETTERS}`, {
       headers,
@@ -96,16 +89,13 @@ test.describe("API Gateway Tests to Verify post Status Endpoint", () => {
   test(`Post /letters returns 400 if request has duplicate id`, async ({
     request,
   }) => {
-    await createTestData(SUPPLIERID, 2);
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 2);
-
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
+    const letterIds: string[] = await createTestData(SUPPLIERID, 2);
+    const createdLetters = await Promise.all(
+      letterIds.map((id) => waitForLetterStatus(SUPPLIERID, id, "PENDING")),
+    );
 
     const headers = postLettersRequestHeaders();
-    const body = postDuplicateIDRequestBody(letters);
+    const body = postDuplicateIDRequestBody(createdLetters);
 
     const response = await request.post(`${baseUrl}/${SUPPLIER_LETTERS}`, {
       headers,
@@ -121,24 +111,21 @@ test.describe("API Gateway Tests to Verify post Status Endpoint", () => {
   test(`Post /letters returns 500 if request has invalid header`, async ({
     request,
   }) => {
-    await createTestData(SUPPLIERID, 4);
-    const letters = await getLettersBySupplier(SUPPLIERID, "PENDING", 4);
-
-    if (!letters?.length) {
-      test.fail(true, `No PENDING letters found for supplier ${SUPPLIERID}`);
-      return;
-    }
+    const letterIds: string[] = await createTestData(SUPPLIERID, 4);
+    const createdLetters = await Promise.all(
+      letterIds.map((id) => waitForLetterStatus(SUPPLIERID, id, "PENDING")),
+    );
 
     const headers = postLettersInvalidRequestHeaders();
     const body = postValidRequestBody({
-      [letters[0].id]: { status: "ACCEPTED" },
-      [letters[1].id]: {
+      [createdLetters[0].id]: { status: "ACCEPTED" },
+      [createdLetters[1].id]: {
         status: "REJECTED",
         reasonCode: "R01",
         reasonText: "Test Reason",
       },
-      [letters[2].id]: { status: "PRINTED" },
-      [letters[3].id]: { status: "CANCELLED" },
+      [createdLetters[2].id]: { status: "PRINTED" },
+      [createdLetters[3].id]: { status: "CANCELLED" },
     });
 
     const response = await request.post(`${baseUrl}/${SUPPLIER_LETTERS}`, {

--- a/tests/component-tests/events-tests/event-subscription.spec.ts
+++ b/tests/component-tests/events-tests/event-subscription.spec.ts
@@ -41,7 +41,7 @@ test.describe("Event Subscription SNS Tests", () => {
       supplierAllocatorLog.msg?.allocationDetails?.supplierSpec?.supplierId;
 
     logger.info(
-      `Supplier ${supplierId} allocated for domainId ${domainId} in supplier allocator lambda`,
+      `Supplier ${supplierId} allocated to letter ${domainId} in supplier allocator lambda`,
     );
     if (!supplierId) {
       throw new Error("supplierId was not found in supplier allocator log");
@@ -109,7 +109,7 @@ test.describe("Event Subscription SNS Tests", () => {
       supplierAllocatorLog.msg?.allocationDetails?.supplierSpec?.supplierId;
 
     logger.info(
-      `Supplier ${supplierId} allocated for domainId ${domainId} in supplier allocator lambda`,
+      `Supplier ${supplierId} allocated to letter ${domainId} in supplier allocator lambda`,
     );
     if (!supplierId) {
       throw new Error("supplierId was not found in supplier allocator log");

--- a/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
+++ b/tests/component-tests/letterQueue-tests/queue-operations.spec.ts
@@ -150,22 +150,22 @@ test.describe("Letter Queue Tests", () => {
     }
     expect(responseBody.data.length).toBeGreaterThanOrEqual(1);
 
-    const currentTimeWithTimeOut = Math.floor(
-      (Date.now() + VISIBILITY_TIMEOUT_SECONDS * 1000) / 1000,
-    );
+    const visibilityTimestampBeforeGet = new Date(
+      letter.visibilityTimestamp,
+    ).getTime();
 
     logger.info(
       "Called Get /letters endpoint verify visibility timestamp is updated and subsequent calls returns no data until visibility timestamp is reached",
     );
     const lettersAfterGet = await getLetterFromQueueById(supplierId, letterId);
-    const visibilityTimestampAfterGet = Math.floor(
-      new Date(lettersAfterGet[0].visibilityTimestamp).getTime() / 1000,
-    );
+    const visibilityTimestampAfterGet = new Date(
+      lettersAfterGet[0].visibilityTimestamp,
+    ).getTime();
 
-    // allow a 1 second tolerance
+    // Verify visibility was pushed forward by at least the configured timeout
     expect(
-      Math.abs(visibilityTimestampAfterGet - currentTimeWithTimeOut),
-    ).toBeLessThanOrEqual(1);
+      visibilityTimestampAfterGet - visibilityTimestampBeforeGet,
+    ).toBeGreaterThanOrEqual(VISIBILITY_TIMEOUT_SECONDS * 1000);
 
     const { responseBody: secondResponseBody, statusCode: secondStatusCode } =
       await getLettersWithRetry(request, baseUrl, headers, {

--- a/tests/config/global-setup.ts
+++ b/tests/config/global-setup.ts
@@ -1,16 +1,11 @@
 import { logger } from "tests/helpers/pino-logger";
 import { supplierDataSetup } from "tests/helpers/suppliers-setup-helper";
-import { createTestData } from "../helpers/generate-fetch-test-data";
 import { SUPPLIERID } from "../constants/api-constants";
 
 async function globalSetup() {
   logger.info("");
   logger.info("*** BEGINNING GLOBAL SETUP ***");
   logger.info("");
-
-  // create test data
-
-  await createTestData(SUPPLIERID, 10);
 
   // check supplier exists
   await supplierDataSetup(SUPPLIERID);

--- a/tests/config/main.config.ts
+++ b/tests/config/main.config.ts
@@ -10,6 +10,11 @@ const localConfig: PlaywrightTestConfig = {
   reporter: getReporters("api-test"),
   projects: [
     {
+      name: "integration-tests",
+      testDir: path.resolve(__dirname, "../component-tests/integration-tests"),
+      testMatch: "**/*.spec.ts",
+    },
+    {
       name: "apiGateway-tests",
       testDir: path.resolve(__dirname, "../component-tests/apiGateway-tests"),
       testMatch: "**/*.spec.ts",
@@ -22,15 +27,10 @@ const localConfig: PlaywrightTestConfig = {
       dependencies: ["apiGateway-tests"],
     },
     {
-      name: "letterQueue-tests",
+      name: "letterQueue-tests", // Needs to run last as tests visibility timeout and can impact other tests if run before them
       testDir: path.resolve(__dirname, "../component-tests/letterQueue-tests"),
       testMatch: "**/*.spec.ts",
-      dependencies: ["apiGateway-tests"],
-    },
-    {
-      name: "integration-tests",
-      testDir: path.resolve(__dirname, "../component-tests/integration-tests"),
-      testMatch: "**/*.spec.ts",
+      dependencies: ["events-tests"],
     },
   ],
 };

--- a/tests/helpers/aws-cloudwatch-helper.ts
+++ b/tests/helpers/aws-cloudwatch-helper.ts
@@ -105,7 +105,7 @@ export async function supplierIdFromSupplierAllocatorLog(
     supplierAllocatorLog.msg?.allocationDetails?.supplierSpec?.supplierId;
 
   logger.info(
-    `Supplier ${supplierId} allocated for domainId ${domainId} in supplier allocator lambda`,
+    `Supplier ${supplierId} allocated to letter ${domainId} in supplier allocator lambda`,
   );
 
   if (!supplierId) {

--- a/tests/helpers/generate-fetch-test-data.ts
+++ b/tests/helpers/generate-fetch-test-data.ts
@@ -17,7 +17,7 @@ import {
   VISIBILITY_TIMEOUT_SECONDS,
   envName,
 } from "../constants/api-constants";
-import { createSupplierData, runCreateLetter } from "./pnpm-helpers";
+import { createSupplierData, runCreateLetter } from "./npm-helpers";
 import { logger } from "./pino-logger";
 import {
   GetLettersResponse,

--- a/tests/helpers/generate-fetch-test-data.ts
+++ b/tests/helpers/generate-fetch-test-data.ts
@@ -7,6 +7,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { APIRequestContext } from "@playwright/test";
 import z from "zod";
+import { Letter } from "@internal/datastore";
 import {
   AWS_ACCOUNT_ID,
   GET_LETTERS_MAX_RETRIES,
@@ -38,23 +39,6 @@ export const PendingLetterSchema = z.object({
 });
 export type PendingLetter = z.infer<typeof PendingLetterSchema>;
 
-export interface SupplierApiLetters {
-  supplierId: string;
-  specificationId: string;
-  supplierStatus: string;
-  createdAt: string;
-  supplierStatusSk: string;
-  updatedAt: string;
-  groupId: string;
-  reasonCode: string;
-  id: string;
-  url: string;
-  ttl: string;
-  reasonText: string;
-  status: string;
-  source: string;
-}
-
 export async function createTestData(
   supplierId: string,
   count?: number,
@@ -82,8 +66,6 @@ export const getLettersBySupplier = async (
     TableName: LETTERSTABLENAME,
     IndexName: "supplierStatus-index",
     KeyConditionExpression: "supplierStatus = :supplierStatus",
-    ProjectionExpression:
-      "id, specificationId, groupId, reasonCode, reasonText",
     ExpressionAttributeValues: {
       ":supplierStatus": supplierStatus,
     },
@@ -94,7 +76,7 @@ export const getLettersBySupplier = async (
   if (!Items || Items.length === 0) {
     throw new Error(`Unexpectedly found no data found for ${supplierId}.`);
   }
-  return Items as SupplierApiLetters[];
+  return Items as Letter[];
 };
 
 const delay = (ms: number) =>
@@ -215,7 +197,7 @@ export async function waitForLetterStatus(
     timeoutMs?: number;
     intervalMs?: number;
   },
-): Promise<SupplierApiLetters> {
+): Promise<Letter> {
   const timeoutMs = options?.timeoutMs ?? 60_000;
   const intervalMs = options?.intervalMs ?? 5000;
   const startedAt = Date.now();
@@ -233,7 +215,7 @@ export async function waitForLetterStatus(
       }),
     );
 
-    const letter = Item as SupplierApiLetters;
+    const letter = Item as Letter;
 
     if (letter && letter.status === status) {
       return letter;

--- a/tests/helpers/generate-fetch-test-data.ts
+++ b/tests/helpers/generate-fetch-test-data.ts
@@ -58,8 +58,8 @@ export interface SupplierApiLetters {
 export async function createTestData(
   supplierId: string,
   count?: number,
-): Promise<void> {
-  await runCreateLetter({
+): Promise<string[]> {
+  return runCreateLetter({
     filter: "nhs-notify-supplier-api-letter-test-data-utility",
     supplierId,
     environment: envName,
@@ -225,7 +225,8 @@ export async function waitForLetterStatus(
       new GetCommand({
         TableName: LETTERSTABLENAME,
         Key: { id, supplierId },
-        ProjectionExpression: "id, #status, supplierId",
+        ProjectionExpression:
+          "id, #status, supplierId, specificationId, groupId, reasonCode, reasonText",
         ExpressionAttributeNames: {
           "#status": "status",
         },

--- a/tests/helpers/npm-helpers.ts
+++ b/tests/helpers/npm-helpers.ts
@@ -77,7 +77,7 @@ export async function runCreateLetter(options: {
     });
     child.on("close", (code) => {
       if (code !== 0) {
-        reject(new Error(`pnpm exited with ${code}`));
+        reject(new Error(`npm exited with ${code}`));
         return;
       }
 
@@ -148,7 +148,7 @@ export async function createSupplierData(options: {
     });
 
     child.on("close", (code) =>
-      code === 0 ? resolve() : reject(new Error(`pnpm exited with ${code}`)),
+      code === 0 ? resolve() : reject(new Error(`npm exited with ${code}`)),
     );
     child.on("error", reject);
   });

--- a/tests/helpers/pnpm-helpers.ts
+++ b/tests/helpers/pnpm-helpers.ts
@@ -16,7 +16,7 @@ export async function runCreateLetter(options: {
   status: string;
   count: number;
   testLetter: string;
-}) {
+}): Promise<string[]> {
   const {
     awsAccountId,
     count,
@@ -63,20 +63,37 @@ export async function runCreateLetter(options: {
     testLetter,
   ];
 
-  await new Promise<void>((resolve, reject) => {
+  return new Promise<string[]>((resolve, reject) => {
     const child = spawn(cmd, args, {
-      stdio: "inherit",
+      stdio: ["inherit", "pipe", "inherit"],
       cwd: root,
       shell: false,
     });
-    child.stdout?.on("id", (id) => {
-      const text = id.toString();
+    let output = "";
+    child.stdout?.on("data", (chunk) => {
+      const text = chunk.toString();
+      output += text;
       process.stdout.write(text);
     });
+    child.on("close", (code) => {
+      if (code !== 0) {
+        reject(new Error(`pnpm exited with ${code}`));
+        return;
+      }
 
-    child.on("close", (code) =>
-      code === 0 ? resolve() : reject(new Error(`pnpm exited with ${code}`)),
-    );
+      const letterIdsMatch = /LETTER_IDS:(\[[^\n]*\])/.exec(output);
+      if (!letterIdsMatch) {
+        reject(new Error("LETTER_IDS not found in output"));
+        return;
+      }
+
+      try {
+        const letterIds = JSON.parse(letterIdsMatch[1]) as string[];
+        resolve(letterIds);
+      } catch (error) {
+        reject(new Error(`Failed to parse LETTER_IDS JSON: ${String(error)}`));
+      }
+    });
     child.on("error", reject);
   });
 }

--- a/tests/helpers/poll-for-letters-helper.ts
+++ b/tests/helpers/poll-for-letters-helper.ts
@@ -12,8 +12,8 @@ export async function pollForLetterStatus(
   const headers = createValidRequestHeaders(supplierId);
   let statusCode = 0;
   let letterStatus: string | undefined;
-  const RETRY_DELAY_MS = 10_000;
-  const MAX_ATTEMPTS = 6;
+  const RETRY_DELAY_MS = 15_000;
+  const MAX_ATTEMPTS = 5;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     const getLetterResponse = await request.get(


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Removes global setup letter creation.

Uses the letterIds sent by the utility.

Each test creates its own letters.


<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
