### PR TITLE
CCM-12600: Add sha256 hash to letters

### DIFF
--- a/internal/datastore/src/types.ts
+++ b/internal/datastore/src/types.ts
@@ -42,6 +42,7 @@ export const LetterSchemaBase = z.object({
   groupId: z.string(),
   reasonCode: z.string().optional(),
   reasonText: z.string().optional(),
+  sha256hash: z.string().optional(),
 });
 
 export const LetterSchema = LetterSchemaBase.extend({

--- a/lambdas/api-handler/src/handlers/__tests__/get-letter-data.test.ts
+++ b/lambdas/api-handler/src/handlers/__tests__/get-letter-data.test.ts
@@ -46,9 +46,43 @@ describe("API Lambda handler", () => {
   it("returns 303 Found with a pre signed url", async () => {
     const mockedGetLetterDataUrlService =
       letterService.getLetterDataUrl as jest.Mock;
-    mockedGetLetterDataUrlService.mockResolvedValue(
-      "https://somePreSignedUrl.com",
-    );
+    mockedGetLetterDataUrlService.mockResolvedValue({
+      presignedUrl: "https://somePreSignedUrl.com",
+      sha256hash: "abc123sha256",
+    });
+
+    const event = makeApiGwEvent({
+      path: "/letters/letter1/data",
+      headers: {
+        "nhsd-supplier-id": "supplier1",
+        "nhsd-correlation-id": "correlationId",
+        "x-request-id": "requestId",
+      },
+      pathParameters: { id: "id1" },
+    });
+    const context = mockDeep<Context>();
+    const callback = jest.fn();
+
+    const getLetterDataHandler = createGetLetterDataHandler(mockedDeps);
+    const result = await getLetterDataHandler(event, context, callback);
+
+    expect(result).toEqual({
+      statusCode: 303,
+      headers: {
+        Location: "https://somePreSignedUrl.com",
+        "X-Notify-File-Sha256": "abc123sha256",
+      },
+      body: "",
+    });
+  });
+
+  it("returns 303 without sha256 header when metadata is absent", async () => {
+    const mockedGetLetterDataUrlService =
+      letterService.getLetterDataUrl as jest.Mock;
+    mockedGetLetterDataUrlService.mockResolvedValue({
+      presignedUrl: "https://somePreSignedUrl.com",
+      sha256hash: undefined,
+    });
 
     const event = makeApiGwEvent({
       path: "/letters/letter1/data",

--- a/lambdas/api-handler/src/handlers/get-letter-data.ts
+++ b/lambdas/api-handler/src/handlers/get-letter-data.ts
@@ -37,7 +37,11 @@ export default function createGetLetterDataHandler(
           ),
         );
 
-        const presignedUrl = await getLetterDataUrl(supplierId, letterId, deps);
+        const downloadDetails = await getLetterDataUrl(
+          supplierId,
+          letterId,
+          deps,
+        );
 
         deps.logger.info({
           description: "Generated presigned URL",
@@ -56,7 +60,10 @@ export default function createGetLetterDataHandler(
         return {
           statusCode: 303,
           headers: {
-            Location: presignedUrl,
+            Location: downloadDetails.presignedUrl,
+            ...(downloadDetails.sha256hash
+              ? { "X-Notify-File-Sha256": downloadDetails.sha256hash }
+              : {}),
           },
           body: "",
         };

--- a/lambdas/api-handler/src/services/__tests__/letter-operations.test.ts
+++ b/lambdas/api-handler/src/services/__tests__/letter-operations.test.ts
@@ -21,6 +21,7 @@ jest.mock("@aws-sdk/client-s3", () => {
   jest.requireActual("@aws-sdk/client-s3");
   return {
     GetObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
+    HeadObjectCommand: jest.fn().mockImplementation((input) => ({ input })),
   };
 });
 
@@ -169,10 +170,14 @@ describe("getLetterDataUrl function", () => {
   };
   const deps: Deps = { s3Client, letterRepo, logger, env } as Deps;
 
-  it("should return pre signed url successfully", async () => {
+  it("should return pre signed url and sha256 metadata successfully", async () => {
     mockedGetSignedUrl.mockResolvedValue("https://somePreSignedUrl.com");
+    (s3Client.send as jest.Mock).mockResolvedValue({
+      Metadata: { sha256hash: "abc123sha256" },
+    });
 
     const result = await getLetterDataUrl("supplier1", "letter1", deps);
+    expect(s3Client.send).toHaveBeenCalledTimes(1);
 
     const expectedCommandInput = {
       Bucket: "letterDataBucket",
@@ -183,7 +188,24 @@ describe("getLetterDataUrl function", () => {
       { input: expectedCommandInput },
       { expiresIn: 60 },
     );
-    expect(result).toEqual("https://somePreSignedUrl.com");
+    expect(result).toEqual({
+      presignedUrl: "https://somePreSignedUrl.com",
+      sha256hash: "abc123sha256",
+    });
+  });
+
+  it("should return undefined sha256 when metadata is absent", async () => {
+    mockedGetSignedUrl.mockResolvedValue("https://somePreSignedUrl.com");
+    (s3Client.send as jest.Mock).mockResolvedValue({
+      Metadata: {},
+    });
+
+    const result = await getLetterDataUrl("supplier1", "letter1", deps);
+
+    expect(result).toEqual({
+      presignedUrl: "https://somePreSignedUrl.com",
+      sha256hash: undefined,
+    });
   });
 
   it("should throw notFoundError when letter does not exist", async () => {

--- a/lambdas/api-handler/src/services/letter-operations.ts
+++ b/lambdas/api-handler/src/services/letter-operations.ts
@@ -5,7 +5,11 @@ import {
   PendingLetterBase,
 } from "@internal/datastore";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { GetObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  GetObjectCommand,
+  HeadObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import { SendMessageBatchCommand } from "@aws-sdk/client-sqs";
 import LetterNotFoundError from "@internal/datastore/src/errors/letter-not-found-error";
 import NotFoundError from "../errors/not-found-error";
@@ -13,21 +17,44 @@ import { UpdateLetterCommand } from "../contracts/letters";
 import { ApiErrorDetail } from "../contracts/errors";
 import { Deps } from "../config/deps";
 
-async function getDownloadUrl(
-  s3Uri: string,
-  s3Client: S3Client,
-  expiry: number,
-) {
+export type LetterDataDownloadDetails = {
+  presignedUrl: string;
+  sha256hash?: string;
+};
+
+function parseS3Uri(s3Uri: string) {
   const url = new URL(s3Uri); // works for s3:// URIs
   const bucket = url.hostname;
   const key = url.pathname.slice(1); // remove leading '/'
 
-  const command = new GetObjectCommand({
+  return { bucket, key };
+}
+
+async function getDownloadDetails(
+  s3Uri: string,
+  s3Client: S3Client,
+  expiry: number,
+): Promise<LetterDataDownloadDetails> {
+  const { bucket, key } = parseS3Uri(s3Uri);
+
+  const getObjectCommand = new GetObjectCommand({
+    Bucket: bucket,
+    Key: key,
+  });
+  const headObjectCommand = new HeadObjectCommand({
     Bucket: bucket,
     Key: key,
   });
 
-  return getSignedUrl(s3Client, command, { expiresIn: expiry });
+  const [presignedUrl, headObject] = await Promise.all([
+    getSignedUrl(s3Client, getObjectCommand, { expiresIn: expiry }),
+    s3Client.send(headObjectCommand),
+  ]);
+
+  return {
+    presignedUrl,
+    sha256hash: headObject.Metadata?.sha256hash,
+  };
 }
 
 function mapPendingLetterToLetterBase(pending: PendingLetterBase): LetterBase {
@@ -85,12 +112,12 @@ export const getLetterDataUrl = async (
   supplierId: string,
   letterId: string,
   deps: Deps,
-): Promise<string> => {
+): Promise<LetterDataDownloadDetails> => {
   let letter;
 
   try {
     letter = await deps.letterRepo.getLetterById(supplierId, letterId);
-    return await getDownloadUrl(
+    return await getDownloadDetails(
       letter.url,
       deps.s3Client,
       deps.env.DOWNLOAD_URL_TTL_SECONDS,

--- a/scripts/utilities/letter-test-data/src/__test__/helpers/s3-helpers.test.ts
+++ b/scripts/utilities/letter-test-data/src/__test__/helpers/s3-helpers.test.ts
@@ -65,8 +65,9 @@ describe("uploadFile", () => {
       Body: Buffer.from("fake-pdf-bytes"),
       ContentType: "application/pdf",
       Metadata: {
-        "sha256hash": "50af8d443ccf8b2777b72a9169cd0665ef4be5335b8f53543556fa0d320b135b",
-      }
+        sha256hash:
+          "50af8d443ccf8b2777b72a9169cd0665ef4be5335b8f53543556fa0d320b135b",
+      },
     });
   });
 

--- a/scripts/utilities/letter-test-data/src/__test__/helpers/s3-helpers.test.ts
+++ b/scripts/utilities/letter-test-data/src/__test__/helpers/s3-helpers.test.ts
@@ -64,6 +64,9 @@ describe("uploadFile", () => {
       Key: `${supplierId}/${targetFilename}`,
       Body: Buffer.from("fake-pdf-bytes"),
       ContentType: "application/pdf",
+      Metadata: {
+        "sha256hash": "50af8d443ccf8b2777b72a9169cd0665ef4be5335b8f53543556fa0d320b135b",
+      }
     });
   });
 

--- a/scripts/utilities/letter-test-data/src/helpers/s3-helpers.ts
+++ b/scripts/utilities/letter-test-data/src/helpers/s3-helpers.ts
@@ -13,7 +13,7 @@ export default async function uploadFile(
     const s3 = new S3Client();
     const filePath = path.join(__dirname, "..", "test-letters", sourceFilename);
     const fileContent = readFileSync(filePath);
-    const hash = createHash('sha256').update(fileContent).digest('hex');
+    const hash = createHash("sha256").update(fileContent).digest("hex");
 
     const uploadParams = {
       Bucket: bucketName,

--- a/scripts/utilities/letter-test-data/src/helpers/s3-helpers.ts
+++ b/scripts/utilities/letter-test-data/src/helpers/s3-helpers.ts
@@ -1,4 +1,5 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -12,12 +13,16 @@ export default async function uploadFile(
     const s3 = new S3Client();
     const filePath = path.join(__dirname, "..", "test-letters", sourceFilename);
     const fileContent = readFileSync(filePath);
+    const hash = createHash('sha256').update(fileContent).digest('hex');
 
     const uploadParams = {
       Bucket: bucketName,
       Key: `${folder}/${targetFilename}`,
       Body: fileContent,
       ContentType: "application/pdf",
+      Metadata: {
+        sha256hash: hash,
+      },
     };
 
     const command = new PutObjectCommand(uploadParams);

--- a/specification/api/components/responses/getDataId303.yml
+++ b/specification/api/components/responses/getDataId303.yml
@@ -2,6 +2,10 @@ description: See Other
 headers:
   Location:
     $ref: "../responseHeaders/getDataLocation.yml"
+  X-Notify-File-Sha256:
+    description: SHA-256 hash of the file from S3 user metadata key sha256.
+    schema:
+      type: string
   X-Request-ID:
     $ref: "../responseHeaders/xRequestId.yml"
   X-Correlation-ID:

--- a/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
+++ b/tests/component-tests/apiGateway-tests/get-letter-pdf.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { createHash } from "node:crypto";
 import getRestApiGatewayBaseUrl from "../../helpers/aws-gateway-helper";
 import {
   createTestData,
@@ -39,8 +40,16 @@ test.describe("API Gateway Tests to Verify Get Letter PDF Endpoint", () => {
     );
 
     expect(response.status()).toBe(200);
-    const responseBody = await response.text();
-    expect(responseBody).toContain("PDF");
+    const responseMetadataSha256 = response.headers()["x-amz-meta-sha256"];
+    expect(responseMetadataSha256).toBeDefined();
+
+    const responseBodyBuffer = await response.body();
+    expect(responseBodyBuffer.toString("utf8")).toContain("PDF");
+
+    const downloadedPdfSha256 = createHash("sha256")
+      .update(responseBodyBuffer)
+      .digest("hex");
+    expect(downloadedPdfSha256).toBe(responseMetadataSha256);
 
     async function fetchUrl(url: string) {
       const res = await request.get(url, { headers });

--- a/tests/constants/request-headers.ts
+++ b/tests/constants/request-headers.ts
@@ -15,6 +15,14 @@ export interface RequestHeaders {
   [key: string]: string;
 }
 
+export const sandBoxHeaderWithHash: RequestSandBoxHeaders = {
+  "X-Request-ID": randomUUID(),
+  "NHSD-Supplier-ID": SUPPLIERID,
+  "Content-Type": "application/vnd.api+json",
+  "X-Correlation-ID": randomUUID(),
+  "x-amz-meta-sha256": "xyz123sha256hash",
+};
+
 export interface RequestSandBoxHeaders {
   "X-Request-ID": string;
   "Content-Type": string;

--- a/tests/sandbox/get-letter-data-sandbox.spec.ts
+++ b/tests/sandbox/get-letter-data-sandbox.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { createHash } from "node:crypto";
 import {
   SUPPLIER_API_URL_SANDBOX,
   SUPPLIER_LETTERS,
@@ -6,6 +7,7 @@ import {
 import {
   RequestSandBoxHeaders,
   sandBoxHeader,
+  sandBoxHeaderWithHash,
 } from "../constants/request-headers";
 
 test.describe("Sandbox Tests To Get Letter Data", () => {
@@ -13,7 +15,7 @@ test.describe("Sandbox Tests To Get Letter Data", () => {
     request,
   }) => {
     const id = "2AL5eYSWGzCHlGmzNxuqVusPxDg";
-    const headers: RequestSandBoxHeaders = sandBoxHeader;
+    const headers: RequestSandBoxHeaders = sandBoxHeaderWithHash;
     const response = await request.get(
       `${SUPPLIER_API_URL_SANDBOX}/${SUPPLIER_LETTERS}/${id}/data`,
       {
@@ -23,6 +25,15 @@ test.describe("Sandbox Tests To Get Letter Data", () => {
 
     expect(response.status()).toBe(200);
     expect(response.headers()["content-type"]).toMatch("application/pdf");
+
+    const responseBodyBuffer = await response.body();
+    const computedSha256 = createHash("sha256")
+      .update(responseBodyBuffer)
+      .digest("hex");
+
+    const expectedSha256 = sandBoxHeaderWithHash["x-amz-meta-sha256"];
+    expect(expectedSha256).toBeDefined();
+    expect(computedSha256).toBe(expectedSha256); // Will need to change the header to include the actual hash of the sandbox pdf for this to work
   });
   test(`Get Letter Data endpoint returns 404 for invalid id`, async ({
     request,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
Letters need to receive the Sha 256 hash of the letter pdf file, and to check that this 
matches with the actual pdf to ensure no tampering has occurred
<!-- Describe your changes in detail. -->
Add hash retrieve to letter retrieval api endpoints
Add hash to sandbox test
Add unit tests
Modify open api spec
Modify component tests

## Context

<!-- Why is this change required? What problem does it solve? -->
We receive a hash of the generated pdf file on an event which is stored as meta data.
However, the api doesn't retrieve the hash or validate that the hash matches the actual file so that 
any tampering could be detected.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
