### PR TITLE
CCM-19310: update pageCount constraint with duplex and sides

### DIFF
--- a/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
+++ b/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
@@ -507,7 +507,7 @@ describe("supplier-config service", () => {
       );
       expect(deps.logger.info).toHaveBeenCalledWith({
         description:
-          "Pack specification spec1 filtered out based on pageCount constraints",
+          "Pack specification filtered out based on pageCount constraints",
         packSpecId: "spec1",
         pageCount: 3,
         violatedConstraints: expect.arrayContaining([
@@ -577,7 +577,7 @@ describe("supplier-config service", () => {
 
       expect(deps.logger.info).toHaveBeenCalledWith({
         description:
-          "Pack specification spec1 filtered out based on pageCount constraints",
+          "Pack specification filtered out based on pageCount constraints",
         packSpecId: "spec1",
         pageCount: 3,
         violatedConstraints: expect.arrayContaining([
@@ -617,7 +617,7 @@ describe("supplier-config service", () => {
 
       expect(deps.logger.info).toHaveBeenCalledWith({
         description:
-          "Pack specification spec1 filtered out based on pageCount constraints",
+          "Pack specification filtered out based on pageCount constraints",
         packSpecId: "spec1",
         pageCount: 3,
         violatedConstraints: expect.arrayContaining([

--- a/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
+++ b/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
@@ -506,15 +506,18 @@ describe("supplier-config service", () => {
         "No eligible pack specifications found for letter variant id undefined and pack specification ids spec1",
       );
       expect(deps.logger.info).toHaveBeenCalledWith({
-        description: "Pack specification spec1 filtered out based on pageCount constraints",
+        description:
+          "Pack specification spec1 filtered out based on pageCount constraints",
         packSpecId: "spec1",
         pageCount: 3,
-        violatedConstraints: expect.arrayContaining([expect.objectContaining({
-          actualValue: 3,
-          constraint: "sheets",
-          constraintValue: 2,
-          operator: "LESS_THAN",
-        })]),
+        violatedConstraints: expect.arrayContaining([
+          expect.objectContaining({
+            actualValue: 3,
+            constraint: "sheets",
+            constraintValue: 2,
+            operator: "LESS_THAN",
+          }),
+        ]),
       });
       expect(deps.logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -528,20 +531,20 @@ describe("supplier-config service", () => {
     it("does not filter pack specification when duplex reduces sheets and constraint is LESS_THAN_OR_EQUAL", async () => {
       const deps = makeDeps();
       deps.supplierConfigRepo.getPackSpecification = jest
-      .fn()
-      .mockResolvedValue({
-        id: "spec1",
-        assembly: { duplex: true },
-        constraints: {
-        sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
-        },
-      } as any);
+        .fn()
+        .mockResolvedValue({
+          id: "spec1",
+          assembly: { duplex: true },
+          constraints: {
+            sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+          },
+        } as any);
 
       const letterEvent = {
-      data: {
-        pageCount: 3,
-        letterVariantId: "variant-1",
-      },
+        data: {
+          pageCount: 3,
+          letterVariantId: "variant-1",
+        },
       } as any;
 
       const result = await filterPacksForLetter(letterEvent, ["spec1"], deps);
@@ -552,12 +555,14 @@ describe("supplier-config service", () => {
 
     it("filters pack specification when sides fail LESS_THAN_OR_EQUAL", async () => {
       const deps = makeDeps();
-      deps.supplierConfigRepo.getPackSpecification = jest.fn().mockResolvedValue({
-        id: "spec1",
-        constraints: {
-          sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
-        },
-      } as any);
+      deps.supplierConfigRepo.getPackSpecification = jest
+        .fn()
+        .mockResolvedValue({
+          id: "spec1",
+          constraints: {
+            sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+          },
+        } as any);
 
       const letterEvent = {
         data: {
@@ -588,14 +593,16 @@ describe("supplier-config service", () => {
 
     it("filters by sides using page count even when duplex is enabled", async () => {
       const deps = makeDeps();
-      deps.supplierConfigRepo.getPackSpecification = jest.fn().mockResolvedValue({
-        id: "spec1",
-        assembly: { duplex: true },
-        constraints: {
-          sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
-          sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
-        },
-      } as any);
+      deps.supplierConfigRepo.getPackSpecification = jest
+        .fn()
+        .mockResolvedValue({
+          id: "spec1",
+          assembly: { duplex: true },
+          constraints: {
+            sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+            sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+          },
+        } as any);
 
       const letterEvent = {
         data: {
@@ -627,20 +634,20 @@ describe("supplier-config service", () => {
     it("does not filter pack specification when sides is valid", async () => {
       const deps = makeDeps();
       deps.supplierConfigRepo.getPackSpecification = jest
-      .fn()
-      .mockResolvedValue({
-        id: "spec1",
-        assembly: { duplex: true },
-        constraints: {
-        sheets: { operator: "LESS_THAN_OR_EQUAL", value: 4 },
-        },
-      } as any);
+        .fn()
+        .mockResolvedValue({
+          id: "spec1",
+          assembly: { duplex: true },
+          constraints: {
+            sheets: { operator: "LESS_THAN_OR_EQUAL", value: 4 },
+          },
+        } as any);
 
       const letterEvent = {
-      data: {
-        pageCount: 3,
-        letterVariantId: "variant-1",
-      },
+        data: {
+          pageCount: 3,
+          letterVariantId: "variant-1",
+        },
       } as any;
 
       const result = await filterPacksForLetter(letterEvent, ["spec1"], deps);
@@ -673,8 +680,6 @@ describe("supplier-config service", () => {
       expect(deps.logger.info).not.toHaveBeenCalled();
       expect(deps.logger.error).not.toHaveBeenCalled();
     });
-
-
 
     it("returns eligible packs for all constraint types", async () => {
       const deps = makeDeps();

--- a/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
+++ b/lambdas/supplier-allocator/src/services/__tests__/supplier-config.test.ts
@@ -483,7 +483,8 @@ describe("supplier-config service", () => {
 
       expect(result).toEqual(["spec1"]);
     });
-    it("throws when no eligible packs found for letter", async () => {
+
+    it("throws when no eligible packs found for letter based on sheets", async () => {
       const deps = makeDeps();
       deps.supplierConfigRepo.getPackSpecification = jest
         .fn()
@@ -505,11 +506,15 @@ describe("supplier-config service", () => {
         "No eligible pack specifications found for letter variant id undefined and pack specification ids spec1",
       );
       expect(deps.logger.info).toHaveBeenCalledWith({
-        description: "Pack specification filtered out based on constraints",
+        description: "Pack specification spec1 filtered out based on pageCount constraints",
         packSpecId: "spec1",
         pageCount: 3,
-        constraintValue: 2,
-        constraintOperator: "LESS_THAN",
+        violatedConstraints: expect.arrayContaining([expect.objectContaining({
+          actualValue: 3,
+          constraint: "sheets",
+          constraintValue: 2,
+          operator: "LESS_THAN",
+        })]),
       });
       expect(deps.logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -519,6 +524,158 @@ describe("supplier-config service", () => {
         }),
       );
     });
+
+    it("does not filter pack specification when duplex reduces sheets and constraint is LESS_THAN_OR_EQUAL", async () => {
+      const deps = makeDeps();
+      deps.supplierConfigRepo.getPackSpecification = jest
+      .fn()
+      .mockResolvedValue({
+        id: "spec1",
+        assembly: { duplex: true },
+        constraints: {
+        sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+        },
+      } as any);
+
+      const letterEvent = {
+      data: {
+        pageCount: 3,
+        letterVariantId: "variant-1",
+      },
+      } as any;
+
+      const result = await filterPacksForLetter(letterEvent, ["spec1"], deps);
+
+      expect(result).toEqual(["spec1"]);
+      expect(deps.logger.info).not.toHaveBeenCalled();
+    });
+
+    it("filters pack specification when sides fail LESS_THAN_OR_EQUAL", async () => {
+      const deps = makeDeps();
+      deps.supplierConfigRepo.getPackSpecification = jest.fn().mockResolvedValue({
+        id: "spec1",
+        constraints: {
+          sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+        },
+      } as any);
+
+      const letterEvent = {
+        data: {
+          pageCount: 3,
+          letterVariantId: "variant-1",
+        },
+      } as any;
+
+      await expect(
+        filterPacksForLetter(letterEvent, ["spec1"], deps),
+      ).rejects.toThrow(/No eligible pack specifications found/);
+
+      expect(deps.logger.info).toHaveBeenCalledWith({
+        description:
+          "Pack specification spec1 filtered out based on pageCount constraints",
+        packSpecId: "spec1",
+        pageCount: 3,
+        violatedConstraints: expect.arrayContaining([
+          expect.objectContaining({
+            constraint: "sides",
+            actualValue: 3,
+            constraintValue: 2,
+            operator: "LESS_THAN_OR_EQUAL",
+          }),
+        ]),
+      });
+    });
+
+    it("filters by sides using page count even when duplex is enabled", async () => {
+      const deps = makeDeps();
+      deps.supplierConfigRepo.getPackSpecification = jest.fn().mockResolvedValue({
+        id: "spec1",
+        assembly: { duplex: true },
+        constraints: {
+          sheets: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+          sides: { operator: "LESS_THAN_OR_EQUAL", value: 2 },
+        },
+      } as any);
+
+      const letterEvent = {
+        data: {
+          pageCount: 3,
+          letterVariantId: "variant-1",
+        },
+      } as any;
+
+      await expect(
+        filterPacksForLetter(letterEvent, ["spec1"], deps),
+      ).rejects.toThrow(/No eligible pack specifications found/);
+
+      expect(deps.logger.info).toHaveBeenCalledWith({
+        description:
+          "Pack specification spec1 filtered out based on pageCount constraints",
+        packSpecId: "spec1",
+        pageCount: 3,
+        violatedConstraints: expect.arrayContaining([
+          expect.objectContaining({
+            constraint: "sides",
+            actualValue: 3,
+            constraintValue: 2,
+            operator: "LESS_THAN_OR_EQUAL",
+          }),
+        ]),
+      });
+    });
+
+    it("does not filter pack specification when sides is valid", async () => {
+      const deps = makeDeps();
+      deps.supplierConfigRepo.getPackSpecification = jest
+      .fn()
+      .mockResolvedValue({
+        id: "spec1",
+        assembly: { duplex: true },
+        constraints: {
+        sheets: { operator: "LESS_THAN_OR_EQUAL", value: 4 },
+        },
+      } as any);
+
+      const letterEvent = {
+      data: {
+        pageCount: 3,
+        letterVariantId: "variant-1",
+      },
+      } as any;
+
+      const result = await filterPacksForLetter(letterEvent, ["spec1"], deps);
+
+      expect(result).toEqual(["spec1"]);
+      expect(deps.logger.info).not.toHaveBeenCalled();
+    });
+
+    it("keeps pack specification when sides constraint passes", async () => {
+      const deps = makeDeps();
+      deps.supplierConfigRepo.getPackSpecification = jest
+        .fn()
+        .mockResolvedValue({
+          id: "spec1",
+          constraints: {
+            sides: { operator: "LESS_THAN_OR_EQUAL", value: 3 },
+          },
+        } as any);
+
+      const letterEvent = {
+        data: {
+          pageCount: 3,
+          letterVariantId: "variant-1",
+        },
+      } as any;
+
+      const result = await filterPacksForLetter(letterEvent, ["spec1"], deps);
+
+      expect(result).toEqual(["spec1"]);
+      expect(deps.logger.info).not.toHaveBeenCalled();
+      expect(deps.logger.error).not.toHaveBeenCalled();
+    });
+
+
+
     it("returns eligible packs for all constraint types", async () => {
       const deps = makeDeps();
       const constraints: { operator: string; value: number }[] = [

--- a/lambdas/supplier-allocator/src/services/supplier-config.ts
+++ b/lambdas/supplier-allocator/src/services/supplier-config.ts
@@ -300,7 +300,7 @@ export async function filterPacksForLetter(
 
       if (violatedConstraints.length > 0) {
         deps.logger.info({
-          description: `Pack specification ${packSpecId} filtered out based on pageCount constraints`,
+          description: `Pack specification filtered out based on pageCount constraints`,
           packSpecId,
           pageCount,
           violatedConstraints,

--- a/lambdas/supplier-allocator/src/services/supplier-config.ts
+++ b/lambdas/supplier-allocator/src/services/supplier-config.ts
@@ -218,35 +218,83 @@ export async function filterPacksForLetter(
   deps: Deps,
 ): Promise<string[]> {
   const filteredPackIds: string[] = [];
+
   for (const packSpecId of packSpecificationIds) {
+    let isValid = true;
+    const violatedConstraints: Array<{
+      constraint: "sheets" | "sides";
+      actualValue: number;
+      constraintValue: number;
+      operator: string;
+    }> = [];
+
     const packSpec =
       await deps.supplierConfigRepo.getPackSpecification(packSpecId);
-    if (
-      !packSpec.constraints ||
-      !packSpec.constraints.sheets ||
-      !packSpec.constraints.sheets.value ||
-      !packSpec.constraints.sheets.operator
-    ) {
-      filteredPackIds.push(packSpecId);
-    } else {
-      const isValid = evaluateContraint(
-        letterEvent.data.pageCount,
-        packSpec.constraints.sheets.value,
-        packSpec.constraints.sheets.operator,
-      );
-      if (isValid) {
-        filteredPackIds.push(packSpecId);
-      } else {
-        deps.logger.info({
-          description: "Pack specification filtered out based on constraints",
-          packSpecId,
-          pageCount: letterEvent.data.pageCount,
-          constraintValue: packSpec.constraints.sheets.value,
-          constraintOperator: packSpec.constraints.sheets.operator,
-        });
+
+    if (packSpec.constraints) {
+      // Evaluate sheets constraint if present
+      if (
+        packSpec.constraints.sheets &&
+        packSpec.constraints.sheets.value !== undefined &&
+        packSpec.constraints.sheets.operator
+      ) {
+        const sheetCount = packSpec?.assembly?.duplex
+          ? Math.ceil(letterEvent.data.pageCount / 2)
+          : letterEvent.data.pageCount;
+
+        const passesSheetsConstraint = evaluateContraint(
+          sheetCount,
+          packSpec.constraints.sheets.value,
+          packSpec.constraints.sheets.operator,
+        );
+
+        if (!passesSheetsConstraint) {
+          isValid = false;
+          violatedConstraints.push({
+            constraint: "sheets",
+            actualValue: sheetCount,
+            constraintValue: packSpec.constraints.sheets.value,
+            operator: packSpec.constraints.sheets.operator,
+          });
+        }
+      }
+
+      // Evaluate sides constraint if present
+      if (
+        packSpec.constraints.sides &&
+        packSpec.constraints.sides.value !== undefined &&
+        packSpec.constraints.sides.operator
+      ) {
+        const passesSidesConstraint = evaluateContraint(
+          letterEvent.data.pageCount,
+          packSpec.constraints.sides.value,
+          packSpec.constraints.sides.operator,
+        );
+
+        if (!passesSidesConstraint) {
+          isValid = false;
+          violatedConstraints.push({
+            constraint: "sides",
+            actualValue: letterEvent.data.pageCount,
+            constraintValue: packSpec.constraints.sides.value,
+            operator: packSpec.constraints.sides.operator,
+          });
+        }
       }
     }
+
+    if (isValid) {
+      filteredPackIds.push(packSpecId);
+    } else {
+      deps.logger.info({
+        description: `Pack specification ${packSpecId} filtered out based on pageCount constraints`,
+        packSpecId,
+        pageCount: letterEvent.data.pageCount,
+        violatedConstraints,
+      });
+    }
   }
+
   if (filteredPackIds.length === 0) {
     deps.logger.error({
       description: "No eligible pack specifications found for letter",

--- a/lambdas/supplier-allocator/src/services/supplier-config.ts
+++ b/lambdas/supplier-allocator/src/services/supplier-config.ts
@@ -212,88 +212,108 @@ function evaluateContraint(
 
 // This function is used to filter the pack specifications for a letter based on the letter data pages and pack specification constraints sheets
 
+type ConstraintName = "sheets" | "sides";
+
+type ViolatedConstraint = {
+  constraint: ConstraintName;
+  actualValue: number;
+  constraintValue: number;
+  operator: string;
+};
+
+function hasConstraint(constraint?: {
+  value?: number;
+  operator?: string;
+}): constraint is { value: number; operator: string } {
+  return constraint?.value !== undefined && constraint.operator !== undefined;
+}
+
+function getViolatedConstraints(
+  pageCount: number,
+  duplex: boolean | undefined,
+  constraints?: {
+    sheets?: { value?: number; operator?: string };
+    sides?: { value?: number; operator?: string };
+  },
+): ViolatedConstraint[] {
+  if (!constraints) {
+    return [];
+  }
+
+  const violations: ViolatedConstraint[] = [];
+
+  if (hasConstraint(constraints.sheets)) {
+    const sheetCount = duplex ? Math.ceil(pageCount / 2) : pageCount;
+    const passes = evaluateContraint(
+      sheetCount,
+      constraints.sheets.value,
+      constraints.sheets.operator,
+    );
+
+    if (!passes) {
+      violations.push({
+        constraint: "sheets",
+        actualValue: sheetCount,
+        constraintValue: constraints.sheets.value,
+        operator: constraints.sheets.operator,
+      });
+    }
+  }
+
+  if (hasConstraint(constraints.sides)) {
+    const passes = evaluateContraint(
+      pageCount,
+      constraints.sides.value,
+      constraints.sides.operator,
+    );
+
+    if (!passes) {
+      violations.push({
+        constraint: "sides",
+        actualValue: pageCount,
+        constraintValue: constraints.sides.value,
+        operator: constraints.sides.operator,
+      });
+    }
+  }
+
+  return violations;
+}
+
 export async function filterPacksForLetter(
   letterEvent: PreparedEvents,
   packSpecificationIds: string[],
   deps: Deps,
 ): Promise<string[]> {
-  const filteredPackIds: string[] = [];
+  const { pageCount } = letterEvent.data;
 
-  for (const packSpecId of packSpecificationIds) {
-    let isValid = true;
-    const violatedConstraints: Array<{
-      constraint: "sheets" | "sides";
-      actualValue: number;
-      constraintValue: number;
-      operator: string;
-    }> = [];
+  const evaluationResults = await Promise.all(
+    packSpecificationIds.map(async (packSpecId) => {
+      const packSpec =
+        await deps.supplierConfigRepo.getPackSpecification(packSpecId);
 
-    const packSpec =
-      await deps.supplierConfigRepo.getPackSpecification(packSpecId);
+      const violatedConstraints = getViolatedConstraints(
+        pageCount,
+        packSpec?.assembly?.duplex,
+        packSpec.constraints,
+      );
 
-    if (packSpec.constraints) {
-      // Evaluate sheets constraint if present
-      if (
-        packSpec.constraints.sheets &&
-        packSpec.constraints.sheets.value !== undefined &&
-        packSpec.constraints.sheets.operator
-      ) {
-        const sheetCount = packSpec?.assembly?.duplex
-          ? Math.ceil(letterEvent.data.pageCount / 2)
-          : letterEvent.data.pageCount;
-
-        const passesSheetsConstraint = evaluateContraint(
-          sheetCount,
-          packSpec.constraints.sheets.value,
-          packSpec.constraints.sheets.operator,
-        );
-
-        if (!passesSheetsConstraint) {
-          isValid = false;
-          violatedConstraints.push({
-            constraint: "sheets",
-            actualValue: sheetCount,
-            constraintValue: packSpec.constraints.sheets.value,
-            operator: packSpec.constraints.sheets.operator,
-          });
-        }
+      if (violatedConstraints.length > 0) {
+        deps.logger.info({
+          description: `Pack specification ${packSpecId} filtered out based on pageCount constraints`,
+          packSpecId,
+          pageCount,
+          violatedConstraints,
+        });
       }
 
-      // Evaluate sides constraint if present
-      if (
-        packSpec.constraints.sides &&
-        packSpec.constraints.sides.value !== undefined &&
-        packSpec.constraints.sides.operator
-      ) {
-        const passesSidesConstraint = evaluateContraint(
-          letterEvent.data.pageCount,
-          packSpec.constraints.sides.value,
-          packSpec.constraints.sides.operator,
-        );
+      return { packSpecId, isValid: violatedConstraints.length === 0 };
+    }),
+  );
 
-        if (!passesSidesConstraint) {
-          isValid = false;
-          violatedConstraints.push({
-            constraint: "sides",
-            actualValue: letterEvent.data.pageCount,
-            constraintValue: packSpec.constraints.sides.value,
-            operator: packSpec.constraints.sides.operator,
-          });
-        }
-      }
-    }
-
-    if (isValid) {
-      filteredPackIds.push(packSpecId);
-    } else {
-      deps.logger.info({
-        description: `Pack specification ${packSpecId} filtered out based on pageCount constraints`,
-        packSpecId,
-        pageCount: letterEvent.data.pageCount,
-        violatedConstraints,
-      });
-    }
-  }
+  const filteredPackIds = evaluationResults
+    .filter((result) => result.isValid)
+    .map((result) => result.packSpecId);
 
   if (filteredPackIds.length === 0) {
     deps.logger.error({
@@ -305,5 +325,6 @@ export async function filterPacksForLetter(
       `No eligible pack specifications found for letter variant id ${letterEvent.data.letterVariantId} and pack specification ids ${packSpecificationIds.join(", ")}`,
     );
   }
+
   return filteredPackIds;
 }

--- a/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
+++ b/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
@@ -58,7 +58,7 @@ test.describe("Allocator Lambda Tests", () => {
     const preparedEvent = createPreparedV1Event({
       domainId,
       letterVariantId: letterVariant,
-      pageCount: 6, // pagecount that makes notify-c5 ineligible and notify-c4 eligible based on their pack configs
+      pageCount: 11, // pagecount that makes notify-c5 ineligible and notify-c4 eligible based on their pack configs (note packs are duplex)
     });
 
     const response = await sendSnsEvent(preparedEvent);

--- a/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
+++ b/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
@@ -65,7 +65,7 @@ test.describe("Allocator Lambda Tests", () => {
     expect(response.MessageId).toBeTruthy();
 
     const supplierAllocatorLog = await getAllocationLog(
-      "Pack specification filtered out based on constraints",
+      "Pack specification filtered out based on pageCount constraints",
     );
     const filteredPackSpecId = supplierAllocatorLog.packSpecId;
     logger.info(`Pack spec filtered out ${filteredPackSpecId}`);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
