### PR TITLE
CCM-20032: Letter Variant SupplierId Not Honoured

### DIFF
--- a/config/suppliers/letter-variant/notify-standard-colour.json
+++ b/config/suppliers/letter-variant/notify-standard-colour.json
@@ -29,6 +29,7 @@
   ],
   "priority": 99,
   "status": "INT",
+  "supplierId": "supplier1",
   "type": "STANDARD",
-  "volumeGroupId": "volumeGroup-test3"
+  "volumeGroupId": "volumeGroup-test1"
 }

--- a/infrastructure/terraform/components/api/module_lambda_upsert_letter.tf
+++ b/infrastructure/terraform/components/api/module_lambda_upsert_letter.tf
@@ -67,8 +67,23 @@ data "aws_iam_policy_document" "upsert_letter_lambda" {
 
     resources = [
       aws_dynamodb_table.letters.arn,
-      aws_dynamodb_table.idempotency.arn,
       "${aws_dynamodb_table.letters.arn}/index/supplierStatus-index"
+    ]
+  }
+
+  statement {
+    sid    = "AllowIdempotencyTableWrite"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:PutItem",
+      "dynamodb:GetItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:DeleteItem"
+    ]
+
+    resources = [
+      aws_dynamodb_table.idempotency.arn,
     ]
   }
 

--- a/lambdas/supplier-allocator/src/handler/__tests__/allocate-handler.test.ts
+++ b/lambdas/supplier-allocator/src/handler/__tests__/allocate-handler.test.ts
@@ -744,6 +744,7 @@ describe("createSupplierAllocatorHandler", () => {
     expect(allocationConfig.selectSupplierByFactor).toHaveBeenCalledWith(
       expect.any(Array),
       expect.any(Array),
+      "letter1",
       mockedDeps,
     );
   });

--- a/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
+++ b/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
@@ -875,6 +875,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
+      "domainId",
       mockDeps,
     );
 
@@ -906,6 +907,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithMissingSupplier,
+      "domainId",
       mockDeps,
     );
 
@@ -937,6 +939,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithZeroPercentage,
+      "domainId",
       mockDeps,
     );
 
@@ -967,7 +970,12 @@ describe("selectSupplierByFactor", () => {
     ];
 
     await expect(
-      selectSupplierByFactor(mockSuppliers, zeroAllocations, mockDeps),
+      selectSupplierByFactor(
+        mockSuppliers,
+        zeroAllocations,
+        "domainId",
+        mockDeps,
+      ),
     ).rejects.toThrow(
       "No valid supplier allocations found for suppliers with valid pack",
     );
@@ -987,6 +995,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
+      "domainId",
       mockDeps,
     );
 
@@ -1006,6 +1015,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       singleSupplier,
       singleAllocation,
+      "domainId",
       mockDeps,
     );
 
@@ -1026,6 +1036,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
+      "domainId",
       mockDeps,
     );
 
@@ -1046,6 +1057,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
+      "domainId",
       mockDeps,
     );
 
@@ -1059,7 +1071,12 @@ describe("selectSupplierByFactor", () => {
     ).mockRejectedValue(error);
 
     await expect(
-      selectSupplierByFactor(mockSuppliers, mockSupplierAllocations, mockDeps),
+      selectSupplierByFactor(
+        mockSuppliers,
+        mockSupplierAllocations,
+        "domainId",
+        mockDeps,
+      ),
     ).rejects.toThrow("Factor calculation error");
   });
 
@@ -1084,6 +1101,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithUnrelatedSupplier,
+      "domainId",
       mockDeps,
     );
 
@@ -1124,6 +1142,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       manySuppliers,
       manyAllocations,
+      "domainId",
       mockDeps,
     );
 
@@ -1136,7 +1155,12 @@ describe("selectSupplierByFactor", () => {
     ).mockResolvedValue([]);
 
     await expect(
-      selectSupplierByFactor(mockSuppliers, mockSupplierAllocations, mockDeps),
+      selectSupplierByFactor(
+        mockSuppliers,
+        mockSupplierAllocations,
+        "domainId",
+        mockDeps,
+      ),
     ).rejects.toThrow("No supplier factors could be calculated for allocation");
   });
 });

--- a/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
+++ b/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
@@ -810,6 +810,7 @@ describe("selectSupplierByFactor", () => {
   let mockDeps: jest.Mocked<Deps>;
   let mockSuppliers: Supplier[];
   let mockSupplierAllocations: SupplierAllocation[];
+  const domainId = "test-domain-id";
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -875,7 +876,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -907,7 +908,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithMissingSupplier,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -939,7 +940,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithZeroPercentage,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -973,7 +974,7 @@ describe("selectSupplierByFactor", () => {
       selectSupplierByFactor(
         mockSuppliers,
         zeroAllocations,
-        "domainId",
+        domainId,
         mockDeps,
       ),
     ).rejects.toThrow(
@@ -995,7 +996,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1015,7 +1016,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       singleSupplier,
       singleAllocation,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1036,7 +1037,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1057,7 +1058,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       mockSupplierAllocations,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1074,7 +1075,7 @@ describe("selectSupplierByFactor", () => {
       selectSupplierByFactor(
         mockSuppliers,
         mockSupplierAllocations,
-        "domainId",
+        domainId,
         mockDeps,
       ),
     ).rejects.toThrow("Factor calculation error");
@@ -1101,7 +1102,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       mockSuppliers,
       allocationsWithUnrelatedSupplier,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1142,7 +1143,7 @@ describe("selectSupplierByFactor", () => {
     const result = await selectSupplierByFactor(
       manySuppliers,
       manyAllocations,
-      "domainId",
+      domainId,
       mockDeps,
     );
 
@@ -1158,7 +1159,7 @@ describe("selectSupplierByFactor", () => {
       selectSupplierByFactor(
         mockSuppliers,
         mockSupplierAllocations,
-        "domainId",
+        domainId,
         mockDeps,
       ),
     ).rejects.toThrow("No supplier factors could be calculated for allocation");

--- a/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
+++ b/lambdas/supplier-allocator/src/handler/__tests__/allocation-config.test.ts
@@ -196,6 +196,37 @@ describe("eligibleSuppliers", () => {
       "Supplier service error",
     );
   });
+  it("should filter allocations by letterVariantSupplierId if provided", async () => {
+    (
+      supplierConfigService.getSupplierAllocationsForVolumeGroup as jest.Mock
+    ).mockResolvedValue(mockSupplierAllocations);
+    (supplierConfigService.getSupplierDetails as jest.Mock).mockResolvedValue(
+      mockSuppliers,
+    );
+
+    const letterVariantSupplierId = "supplier-1";
+    await eligibleSuppliers(mockVolumeGroup, mockDeps, letterVariantSupplierId);
+    expect(supplierConfigService.getSupplierDetails).toHaveBeenCalledWith(
+      ["supplier-1"],
+      mockDeps,
+    );
+  });
+  it("should log a warning if no allocations found for specified letter variant supplier", async () => {
+    (
+      supplierConfigService.getSupplierAllocationsForVolumeGroup as jest.Mock
+    ).mockResolvedValue([]);
+    (supplierConfigService.getSupplierDetails as jest.Mock).mockResolvedValue(
+      [],
+    );
+
+    const letterVariantSupplierId = "supplier-1";
+    await eligibleSuppliers(mockVolumeGroup, mockDeps, letterVariantSupplierId);
+    expect(mockDeps.logger.warn).toHaveBeenCalledWith({
+      description: "No allocations found for specified letter variant supplier",
+      volumeGroupId: mockVolumeGroup.id,
+      letterVariantSupplierId,
+    });
+  });
 });
 
 describe("preferredSupplierPack", () => {

--- a/lambdas/supplier-allocator/src/handler/allocate-handler.ts
+++ b/lambdas/supplier-allocator/src/handler/allocate-handler.ts
@@ -94,7 +94,7 @@ async function getSupplierFromConfig(
     );
 
     const { supplierAllocations, suppliers: allocatedSuppliers } =
-      await eligibleSuppliers(volumeGroup, deps);
+      await eligibleSuppliers(volumeGroup, deps, letterVariant.supplierId);
 
     const preferredPack: PackSpecification = await preferredSupplierPack(
       letterEvent,
@@ -391,6 +391,9 @@ export default function createSupplierAllocatorHandler(deps: Deps): SQSHandler {
 
         ({ priority, supplier } = supplierAllocationResult);
       } catch (error) {
+        console.log(
+          `Error processing allocation of record ${record.messageId}: ${error}`,
+        );
         deps.logger.error({
           description: "Error processing allocation of record",
           err: error,

--- a/lambdas/supplier-allocator/src/handler/allocate-handler.ts
+++ b/lambdas/supplier-allocator/src/handler/allocate-handler.ts
@@ -124,12 +124,14 @@ async function getSupplierFromConfig(
         ? await selectSupplierByFactor(
             suppliersForPackWithCapacity,
             supplierAllocations,
+            letterEvent.data.domainId,
             deps,
           )
         : undefined) ??
       (await selectSupplierByFactor(
         allSuppliersForPack,
         supplierAllocations,
+        letterEvent.data.domainId,
         deps,
       ));
 

--- a/lambdas/supplier-allocator/src/handler/allocate-handler.ts
+++ b/lambdas/supplier-allocator/src/handler/allocate-handler.ts
@@ -29,7 +29,6 @@ import {
   selectSupplierByFactor,
   suppliersWithValidPack,
 } from "./allocation-config";
-
 import { Deps } from "../config/deps";
 import { PreparedEventSchema, PreparedEvents, SupplierDetails } from "./types";
 
@@ -136,6 +135,7 @@ async function getSupplierFromConfig(
 
     deps.logger.info({
       description: "Fetched supplier details for supplier allocations",
+      domainId: letterEvent.data.domainId,
       variantId: letterEvent.data.letterVariantId,
       volumeGroupId: volumeGroup.id,
       supplierAllocationIds: supplierAllocations.map((a) => a.id),

--- a/lambdas/supplier-allocator/src/handler/allocate-handler.ts
+++ b/lambdas/supplier-allocator/src/handler/allocate-handler.ts
@@ -393,9 +393,6 @@ export default function createSupplierAllocatorHandler(deps: Deps): SQSHandler {
 
         ({ priority, supplier } = supplierAllocationResult);
       } catch (error) {
-        console.log(
-          `Error processing allocation of record ${record.messageId}: ${error}`,
-        );
         deps.logger.error({
           description: "Error processing allocation of record",
           err: error,

--- a/lambdas/supplier-allocator/src/handler/allocation-config.ts
+++ b/lambdas/supplier-allocator/src/handler/allocation-config.ts
@@ -38,10 +38,10 @@ export async function eligibleSuppliers(
       volumeGroupId: volumeGroup.id,
       letterVariantSupplierId,
     });
-    const filteredAllocations = supplierAllocations.filter(
+    const filteredAllocations = supplierAllocations.find(
       (alloc) => alloc.supplier === letterVariantSupplierId,
     );
-    if (filteredAllocations.length === 0) {
+    if (!filteredAllocations) {
       deps.logger.warn({
         description:
           "No allocations found for specified letter variant supplier",
@@ -50,9 +50,9 @@ export async function eligibleSuppliers(
       });
     }
     return {
-      supplierAllocations: filteredAllocations,
+      supplierAllocations: filteredAllocations ? [filteredAllocations] : [],
       suppliers: await getSupplierDetails(
-        filteredAllocations.map((alloc) => alloc.supplier),
+        filteredAllocations ? [filteredAllocations.supplier] : [],
         deps,
       ),
     };

--- a/lambdas/supplier-allocator/src/handler/allocation-config.ts
+++ b/lambdas/supplier-allocator/src/handler/allocation-config.ts
@@ -148,6 +148,7 @@ export async function filterSuppliersWithCapacity(
 export async function selectSupplierByFactor(
   suppliers: Supplier[],
   supplierAllocations: SupplierAllocation[],
+  domainId: string,
   deps: Deps,
 ): Promise<string> {
   const supplierAllocationsForPack = supplierAllocations.filter((alloc) => {
@@ -175,6 +176,7 @@ export async function selectSupplierByFactor(
 
   deps.logger.info({
     description: "Calculated supplier factors for allocation",
+    domainId,
     supplierFactors,
   });
   let selectedSupplierId = supplierFactors[0].supplierId;

--- a/lambdas/supplier-allocator/src/handler/allocation-config.ts
+++ b/lambdas/supplier-allocator/src/handler/allocation-config.ts
@@ -23,6 +23,7 @@ import { PreparedEvents } from "./types";
 export async function eligibleSuppliers(
   volumeGroup: VolumeGroup,
   deps: Deps,
+  letterVariantSupplierId?: string,
 ): Promise<{
   supplierAllocations: SupplierAllocation[];
   suppliers: Supplier[];
@@ -31,6 +32,32 @@ export async function eligibleSuppliers(
     volumeGroup.id,
     deps,
   );
+  if (letterVariantSupplierId) {
+    deps.logger.info({
+      description: "Filtering allocations for letter variant supplier",
+      volumeGroupId: volumeGroup.id,
+      letterVariantSupplierId,
+    });
+    const filteredAllocations = supplierAllocations.filter(
+      (alloc) => alloc.supplier === letterVariantSupplierId,
+    );
+    if (filteredAllocations.length === 0) {
+      deps.logger.warn({
+        description:
+          "No allocations found for specified letter variant supplier",
+        volumeGroupId: volumeGroup.id,
+        letterVariantSupplierId,
+      });
+    }
+    return {
+      supplierAllocations: filteredAllocations,
+      suppliers: await getSupplierDetails(
+        filteredAllocations.map((alloc) => alloc.supplier),
+        deps,
+      ),
+    };
+  }
+
   const allocationPercentageSum = supplierAllocations.reduce(
     (sum, alloc) => sum + alloc.allocationPercentage,
     0,

--- a/lambdas/supplier-allocator/src/services/supplier-config.ts
+++ b/lambdas/supplier-allocator/src/services/supplier-config.ts
@@ -301,6 +301,7 @@ export async function filterPacksForLetter(
       if (violatedConstraints.length > 0) {
         deps.logger.info({
           description: `Pack specification filtered out based on pageCount constraints`,
+          dommainId: letterEvent.data.domainId,
           packSpecId,
           pageCount,
           violatedConstraints,

--- a/tests/component-tests/allocation-tests/allocation-letter-variant.spec.ts
+++ b/tests/component-tests/allocation-tests/allocation-letter-variant.spec.ts
@@ -12,7 +12,7 @@ import { sendSnsEvent } from "tests/helpers/send-sns-event";
 test.describe("Letter Variant Tests", () => {
   test.setTimeout(180_000); // 3 minutes for long running polling
 
-  test("Verify that supplierId on letter variant takes pecedence over volume group", async () => {
+  test("Verify that supplierId on letter variant takes precedence over volume group", async () => {
     const letterVariant = getVariantsForAllocation(3);
     const domainId = randomUUID();
     const preparedEvent = createPreparedV1Event({

--- a/tests/component-tests/allocation-tests/allocation-letter-variant.spec.ts
+++ b/tests/component-tests/allocation-tests/allocation-letter-variant.spec.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+import { expect, test } from "@playwright/test";
+import {
+  FetchedSupplierLog,
+  getAllocationDetailsForDomainId,
+  getVariantsForAllocation,
+} from "tests/helpers/allocation-helper";
+
+import { createPreparedV1Event } from "tests/helpers/event-fixtures";
+import { sendSnsEvent } from "tests/helpers/send-sns-event";
+
+test.describe("Letter Variant Tests", () => {
+  test.setTimeout(180_000); // 3 minutes for long running polling
+
+  test("Verify that supplierId on letter variant takes pecedence over volume group", async () => {
+    const letterVariant = getVariantsForAllocation(3);
+    const domainId = randomUUID();
+    const preparedEvent = createPreparedV1Event({
+      domainId,
+      letterVariantId: letterVariant,
+    });
+
+    const response = await sendSnsEvent(preparedEvent);
+
+    expect(response.MessageId).toBeTruthy();
+
+    const allocationDetails: FetchedSupplierLog =
+      await getAllocationDetailsForDomainId(domainId);
+
+    expect(allocationDetails.allocatedSuppliers).toHaveLength(1);
+
+    const allocatedSupplierId = allocationDetails.allocatedSuppliers?.[0]?.id;
+    expect(allocatedSupplierId).toBe("supplier1");
+  });
+});

--- a/tests/component-tests/allocation-tests/allocation-target-percentage.spec.ts
+++ b/tests/component-tests/allocation-tests/allocation-target-percentage.spec.ts
@@ -6,6 +6,7 @@ import {
   getSupplierFromSupplierPack,
   getVariantsForAllocation,
   updateSupplierAllocation,
+  updateVolumeGroupData,
 } from "tests/helpers/allocation-helper";
 import { createPreparedV1Event } from "tests/helpers/event-fixtures";
 import { getLettersFromSupplierTable } from "tests/helpers/generate-fetch-test-data";
@@ -16,10 +17,22 @@ test.describe("Allocation Target Percentage Tests", () => {
   test("Verify that supplier with zero target percentage is handled correctly", async () => {
     const letterVariant = getVariantsForAllocation(8);
     const domainId = `Zero-Percentage-${randomUUID()}`;
-
     const letterVariantConfig =
       await getLetterVariantConfigFromDb(letterVariant);
     const volGroupId = letterVariantConfig.volumeGroupId;
+
+    // ensure volume group is valid.
+    const [pastStartDate] = new Date(Date.now() - 1000 * 60 * 60 * 24)
+      .toISOString()
+      .split("T");
+
+    await updateVolumeGroupData(volGroupId, pastStartDate, "startDate");
+
+    const [futureEnd] = new Date(Date.now() + 1000 * 60 * 60 * 24)
+      .toISOString()
+      .split("T");
+
+    await updateVolumeGroupData(volGroupId, futureEnd, "endDate");
 
     // update target percentage
     await updateSupplierAllocation("supplier1", volGroupId, 0);

--- a/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
+++ b/tests/component-tests/allocation-tests/letter-allocation-capacity.spec.ts
@@ -66,6 +66,7 @@ test.describe("Allocator Lambda Tests", () => {
 
     const supplierAllocatorLog = await getAllocationLog(
       "Pack specification filtered out based on pageCount constraints",
+      { extraPatterns: [domainId] },
     );
     const filteredPackSpecId = supplierAllocatorLog.packSpecId;
     logger.info(`Pack spec filtered out ${filteredPackSpecId}`);

--- a/tests/component-tests/allocation-tests/letter-allocation-weighting.spec.ts
+++ b/tests/component-tests/allocation-tests/letter-allocation-weighting.spec.ts
@@ -97,6 +97,7 @@ test.describe("Allocator Weighting Tests", () => {
         "Calculated supplier factors for allocation",
         {
           startTimeMs: testStartedAt,
+          extraPatterns: [domainId],
         },
       );
 

--- a/tests/component-tests/allocation-tests/supplier-allocation.spec.ts
+++ b/tests/component-tests/allocation-tests/supplier-allocation.spec.ts
@@ -117,6 +117,8 @@ test.describe("Supplier Allocation Tests", () => {
     logger.info(
       `New total daily allocation for date ${allocationDate}: ${newTotalDailyAllocation}`,
     );
-    expect(newTotalDailyAllocation).toBe(originalTotalDailyAllocation + 1);
+    expect(newTotalDailyAllocation).toBeGreaterThanOrEqual(
+      originalTotalDailyAllocation + 1,
+    );
   });
 });

--- a/tests/helpers/allocation-helper.ts
+++ b/tests/helpers/allocation-helper.ts
@@ -10,6 +10,7 @@ import { logger } from "tests/helpers/pino-logger";
 import { envName } from "tests/constants/api-constants";
 import {
   pollAllocatorLogWithOptions,
+  pollSupplierAllocatorLogForAllocationDetails,
   pollSupplierAllocatorLogForExceededDailyCapacity,
   pollSupplierAllocatorLogForResolvedSpec,
 } from "./aws-cloudwatch-helper";
@@ -84,6 +85,22 @@ export type AllocationLogOptions = {
   extraPatterns?: string[];
 };
 
+export type AllocatedSuppliersLogEntry = {
+  id: string;
+  name: string;
+  channelType: string;
+  dailyCapacity: number;
+  status: string;
+};
+
+export type FetchedSupplierLog = {
+  supplierAllocationIds?: string[];
+  allocatedSuppliers?: AllocatedSuppliersLogEntry[];
+  allSuppliersForPack?: string[];
+  supplierForPackWithCapacity?: string[];
+  selectedSupplierId?: string;
+};
+
 type LetterVariantConfig = {
   id: string;
   packSpecificationIds: string[];
@@ -136,6 +153,15 @@ export async function getAllocationLogForDomainId(
   const supplierAllocatorLog = JSON.parse(message) as SupplierAllocatorLog;
 
   return supplierAllocatorLog;
+}
+
+export async function getAllocationDetailsForDomainId(
+  domainId: string,
+): Promise<FetchedSupplierLog> {
+  const message = await pollSupplierAllocatorLogForAllocationDetails(domainId);
+  const fetchedSupplierLog = JSON.parse(message) as FetchedSupplierLog;
+
+  return fetchedSupplierLog;
 }
 
 export async function getAllocationLog<

--- a/tests/helpers/aws-cloudwatch-helper.ts
+++ b/tests/helpers/aws-cloudwatch-helper.ts
@@ -60,6 +60,16 @@ export async function pollSupplierAllocatorLogForResolvedSpec(
     `"${domainId}"`,
   ]);
 }
+
+export async function pollSupplierAllocatorLogForAllocationDetails(
+  domainId: string,
+): Promise<string> {
+  return pollLambdaLog("supplier-allocator", [
+    '"Fetched supplier details for supplier allocations"',
+    `"${domainId}"`,
+  ]);
+}
+
 export async function pollSupplierAllocatorLogForError(
   msgToCheck: string,
   domainId?: string,


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

<!-- Describe your changes in detail. -->

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming
<!-- - [ ] If I have used the 'skip-trivy-package' label I have done so responsibly and in the knowledge that this is being fixed as part of a separate ticket/PR. TODO - Re-visit Trivy usage https://nhsd-jira.digital.nhs.uk/browse/CCM-15549 -->

## DT3-Specific Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
