### PR TITLE
CCM-19739: Upgrade actions/cache to v6.1.0

### DIFF
--- a/.github/actions/build-oas-spec/action.yml
+++ b/.github/actions/build-oas-spec/action.yml
@@ -35,7 +35,7 @@ runs:
         registry-url: 'https://npm.pkg.github.com'
 
     - name: "Cache node_modules"
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: |
           **/node_modules

--- a/.github/workflows/stage-2-test.yaml
+++ b/.github/workflows/stage-2-test.yaml
@@ -55,7 +55,7 @@ jobs:
           node-version: ${{ inputs.nodejs_version }}
           registry-url: "https://npm.pkg.github.com"
       - name: "Cache node_modules"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -86,7 +86,7 @@ jobs:
           node-version: ${{ inputs.nodejs_version }}
           registry-url: "https://npm.pkg.github.com"
       - name: "Cache node_modules"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -129,7 +129,7 @@ jobs:
       - name: "Checkout code"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "Cache node_modules"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -162,7 +162,7 @@ jobs:
           node-version: ${{ inputs.nodejs_version }}
           registry-url: "https://npm.pkg.github.com"
       - name: "Cache node_modules"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules
@@ -195,7 +195,7 @@ jobs:
           node-version: ${{ inputs.nodejs_version }}
           registry-url: "https://npm.pkg.github.com"
       - name: "Cache node_modules"
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             **/node_modules


### PR DESCRIPTION
## Description

Upgrades `actions/cache` to v6.1.0 across workflow and composite action files.

- `.github/workflows/stage-2-test.yaml` — five cache steps updated
- `.github/actions/build-oas-spec/action.yml` — updated

## Context

CCM-19739: `actions/cache` v6.1.0 moves the action runtime from Node 20 to Node 22. This change upgrades all usages in this repo to the latest version.

## Type of changes

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

## DT3-Specific Checklist

- [ ] If I have added a new resource (SQS, Lambda, Gateway, DDB table, etc), I have created the appropriate alarms

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.